### PR TITLE
fix unused imports issue

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1366,7 +1366,9 @@ func (g *Generator) generateImports() {
 	g.P("var _ = ", g.Pkg["fmt"], ".Errorf")
 	g.P("var _ = ", g.Pkg["math"], ".Inf")
 	for pkgName, typeName := range g.usedPackages {
-		g.P("var _ = ", pkgName, ".", typeName, "{}")
+		if pkgName != g.packageName {
+			g.P("var _ = ", pkgName, ".", typeName, "{}")
+		}
 	}
 	g.P()
 }


### PR DESCRIPTION
Say, I'm creating a `foo.proto` file.

Currently, if I do `import public "some/package/bar.proto"` in my `foo.proto` file, and never refer to any of the `bar`'s services - I get a compiler error complaining about the unused import. The reason is that in the generated  `bar.micro.go` no code is generated that would refer to any of the `foo` package types.

I suggest to keep a map of "package name" <=> "type name" (doesn't really matter which type name), and then use that type name to create a blank identifier, so it would get rid of the compiler error.