### PR TITLE
Handle server Handle() error

### DIFF
--- a/examples/greeter/greeter.micro.go
+++ b/examples/greeter/greeter.micro.go
@@ -79,7 +79,7 @@ type GreeterHandler interface {
 	Hello(context.Context, *Request, *Response) error
 }
 
-func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server.HandlerOption) {
+func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server.HandlerOption) error {
 	type greeter interface {
 		Hello(ctx context.Context, in *Request, out *Response) error
 	}
@@ -87,7 +87,7 @@ func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server
 		greeter
 	}
 	h := &greeterHandler{hdlr}
-	s.Handle(s.NewHandler(&Greeter{h}, opts...))
+	return s.Handle(s.NewHandler(&Greeter{h}, opts...))
 }
 
 type greeterHandler struct {

--- a/plugin/micro/micro.go
+++ b/plugin/micro/micro.go
@@ -188,7 +188,7 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 	g.P()
 
 	// Server registration.
-	g.P("func Register", servName, "Handler(s ", serverPkg, ".Server, hdlr ", serverType, ", opts ...", serverPkg, ".HandlerOption) {")
+	g.P("func Register", servName, "Handler(s ", serverPkg, ".Server, hdlr ", serverType, ", opts ...", serverPkg, ".HandlerOption) error {")
 	g.P("type ", unexport(servName), " interface {")
 
 	// generate interface methods
@@ -208,7 +208,7 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 	g.P(unexport(servName))
 	g.P("}")
 	g.P("h := &", unexport(servName), "Handler{hdlr}")
-	g.P("s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
+	g.P("return s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
 	g.P("}")
 	g.P()
 


### PR DESCRIPTION
This PR handles service server `Handle()` method error by panicking (returning error would break backward compatibility).

See #16 