### PR TITLE
Add api endpoint code

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Usage:
 1. Clone `github.com/googleapis/googleapis` to use this feature as it requires http annotations.
 2. The protoc command must include `-I$GOPATH/src/github.com/googleapis/googleapis` for the annotations import.
 
-```
+```diff
 syntax = "proto3";
 
 import "google/api/annotations.proto";
@@ -110,7 +110,7 @@ message Response {
 
 The proto generates a `RegisterGreeterHandler` function with a [go-api.Endpoint](https://godoc.org/github.com/micro/go-api#Endpoint). 
 
-```go
+```diff
 func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server.HandlerOption) error {
 	type greeter interface {
 		Hello(ctx context.Context, in *Request, out *Response) error

--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ syntax = "proto3";
 import "google/api/annotations.proto";
 
 service Greeter {
-	rpc Hello(Request) returns (Response) {
-		option (google.api.http) = {
-			post: "/hello"
-		};	
-	}
+-	rpc Hello(Request) returns (Response) {}
++	rpc Hello(Request) returns (Response) {
++		option (google.api.http) = {
++			post: "/hello"
++		};	
++	}
 }
 
 message Request {
@@ -118,13 +119,14 @@ func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server
 		greeter
 	}
 	h := &greeterHandler{hdlr}
-	opts = append(opts, api.WithEndpoint(&api.Endpoint{
-		Name:    "Greeter.Hello",
-		Path:    []string{"/hello"},
-		Method:  []string{"POST"},
-		Handler: "rpc",
-	}))
-	return s.Handle(s.NewHandler(&Greeter{h}, opts...))
+-	s.Handle(s.NewHandler(&Greeter{h}, opts...))
++	opts = append(opts, api.WithEndpoint(&api.Endpoint{
++		Name:    "Greeter.Hello",
++		Path:    []string{"/hello"},
++		Method:  []string{"POST"},
++		Handler: "rpc",
++	}))
++	return s.Handle(s.NewHandler(&Greeter{h}, opts...))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ client := proto.NewGreeterService("greeter", service.Client())
 
 Add a micro API endpoint which routes directly to an RPC method
 
+Usage:
+
+1. Clone `github.com/googleapis/googleapis` to use this feature as it requires http annotations.
+2. The protoc command must include `-I$GOPATH/src/github.com/googleapis/googleapis` for the annotations import.
+
 ```
 syntax = "proto3";
 
@@ -101,7 +106,6 @@ message Response {
 	string msg = 1;
 }
 ```
-
 
 The proto generates a `RegisterGreeterHandler` function with a [go-api.Endpoint](https://godoc.org/github.com/micro/go-api#Endpoint). 
 

--- a/plugin/micro/micro.go
+++ b/plugin/micro/micro.go
@@ -6,14 +6,17 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/protobuf/proto"
 	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/micro/protoc-gen-micro/generator"
+	options "google.golang.org/genproto/googleapis/api/annotations"
 )
 
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
 const (
 	contextPkgPath = "context"
+	apiPkgPath     = "github.com/micro/go-api"
 	clientPkgPath  = "github.com/micro/go-micro/client"
 	serverPkgPath  = "github.com/micro/go-micro/server"
 )
@@ -37,6 +40,7 @@ func (g *micro) Name() string {
 // They may vary from the final path component of the import path
 // if the name is used by other packages.
 var (
+	apiPkg string
 	contextPkg string
 	clientPkg  string
 	serverPkg  string
@@ -45,6 +49,7 @@ var (
 // Init initializes the plugin.
 func (g *micro) Init(gen *generator.Generator) {
 	g.gen = gen
+	apiPkg = generator.RegisterUniquePackageName("api", nil)
 	contextPkg = generator.RegisterUniquePackageName("context", nil)
 	clientPkg = generator.RegisterUniquePackageName("client", nil)
 	serverPkg = generator.RegisterUniquePackageName("server", nil)
@@ -71,6 +76,7 @@ func (g *micro) Generate(file *generator.FileDescriptor) {
 		return
 	}
 	g.P("// Reference imports to suppress errors if they are not otherwise used.")
+	g.P("var _ ", apiPkg, ".Endpoint")
 	g.P("var _ ", contextPkg, ".Context")
 	g.P("var _ ", clientPkg, ".Option")
 	g.P("var _ ", serverPkg, ".Option")
@@ -87,6 +93,7 @@ func (g *micro) GenerateImports(file *generator.FileDescriptor) {
 		return
 	}
 	g.P("import (")
+	g.P(apiPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, apiPkgPath)))
 	g.P(clientPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, clientPkgPath)))
 	g.P(serverPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, serverPkgPath)))
 	g.P(contextPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, contextPkgPath)))
@@ -208,7 +215,10 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 	g.P(unexport(servName))
 	g.P("}")
 	g.P("h := &", unexport(servName), "Handler{hdlr}")
-	g.P("return s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
+	for _, method := range service.Method {
+		g.generateEndpoint(servName, method)
+		g.P("return s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
+	}
 	g.P("}")
 	g.P()
 
@@ -222,6 +232,48 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 		hname := g.generateServerMethod(servName, method)
 		handlerNames = append(handlerNames, hname)
 	}
+}
+
+// generateEndpoint creates the api endpoint
+func (g *micro) generateEndpoint(servName string, method *pb.MethodDescriptorProto) {
+	if method.Options == nil || !proto.HasExtension(method.Options, options.E_Http) {
+		return
+	}
+	// http rules
+	r, err := proto.GetExtension(method.Options, options.E_Http)
+	if err != nil {
+		return
+	}
+	rule := r.(*options.HttpRule)
+	var meth string
+	var path string
+	switch {
+	case len(rule.GetDelete()) > 0:
+		meth = "DELETE"
+		path = rule.GetDelete()
+	case len(rule.GetGet()) > 0:
+		meth = "GET"
+		path = rule.GetGet()
+	case len(rule.GetPatch()) > 0:
+		meth = "PATCH"
+		path = rule.GetPatch()
+	case len(rule.GetPost()) > 0:
+		meth = "POST"
+		path = rule.GetPost()
+	case len(rule.GetPut()) > 0:
+		meth = "PUT"
+		path = rule.GetPut()
+	}
+	if len(meth) == 0 || len(path) == 0 {
+		return
+	}
+	// TODO: process additional bindings
+	g.P("opts = append(opts, ", apiPkg, ".WithEndpoint(&", apiPkg, ".Endpoint{")
+	g.P("Name:", fmt.Sprintf(`"%s.%s",`, servName, method.GetName()))
+	g.P("Path:", fmt.Sprintf(`[]string{"%s"},`, path))
+	g.P("Method:", fmt.Sprintf(`[]string{"%s"},`, meth))
+	g.P("Handler: \"rpc\",")
+	g.P("}))")
 }
 
 // generateClientSignature returns the client-side signature for a method.


### PR DESCRIPTION
This PR adds code generation for specifying micro API endpoints for RPC methods through service endpoint metadata. This is a feature that will allow dynamic routing to specify a http endpoint and its mapping to a backend service.

You must clone `github.com/googleapis/googleapis` for this to work as we require http annotations.

Your protoc command must include `-I$GOPATH/src/github.com/googleapis/googleapis`

```
syntax = "proto3";

import "google/api/annotations.proto";

service Greeter {
	rpc Hello(Request) returns (Response) {
		option (google.api.http) = {
			post: "/hello"
		};	
	}
}

message Request {
	string name = 1;
}

message Response {
	string msg = 1;
}
```

The proto generates a `RegisterGreeterHandler` function with a [go-api.Endpoint](https://godoc.org/github.com/micro/go-api#Endpoint). 

```go
func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server.HandlerOption) error {
	type greeter interface {
		Hello(ctx context.Context, in *Request, out *Response) error
	}
	type Greeter struct {
		greeter
	}
	h := &greeterHandler{hdlr}
	opts = append(opts, api.WithEndpoint(&api.Endpoint{
		Name:    "Greeter.Hello",
		Path:    []string{"/hello"},
		Method:  []string{"POST"},
		Handler: "rpc",
	}))
	return s.Handle(s.NewHandler(&Greeter{h}, opts...))
}
```