### PR TITLE
Fix return on loop

### DIFF
--- a/plugin/micro/micro.go
+++ b/plugin/micro/micro.go
@@ -40,7 +40,7 @@ func (g *micro) Name() string {
 // They may vary from the final path component of the import path
 // if the name is used by other packages.
 var (
-	apiPkg string
+	apiPkg     string
 	contextPkg string
 	clientPkg  string
 	serverPkg  string
@@ -217,8 +217,8 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 	g.P("h := &", unexport(servName), "Handler{hdlr}")
 	for _, method := range service.Method {
 		g.generateEndpoint(servName, method)
-		g.P("return s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
 	}
+	g.P("return s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
 	g.P("}")
 	g.P()
 


### PR DESCRIPTION
I found this issue

```go
func RegisterProductHandler(s server.Server, hdlr ProductHandler, opts ...server.HandlerOption) error {
	type product interface {
		Get(ctx context.Context, in *go_api.Request, out *go_api.Response) error
		Create(ctx context.Context, in *go_api.Request, out *go_api.Response) error
	}
	type Product struct {
		product
	}
	h := &productHandler{hdlr}
	opts = append(opts, api.WithEndpoint(&api.Endpoint{
		Name:    "Product.Get",
		Path:    []string{"/book"},
		Method:  []string{"GET"},
		Handler: "rpc",
	}))
	return s.Handle(s.NewHandler(&Product{h}, opts...))
	opts = append(opts, api.WithEndpoint(&api.Endpoint{
		Name:    "Product.Create",
		Path:    []string{"/books"},
		Method:  []string{"POST"},
		Handler: "rpc",
	}))
	return s.Handle(s.NewHandler(&Product{h}, opts...))
}
```