### PR TITLE
Fix import for Go Modules

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -47,6 +47,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -1337,6 +1338,15 @@ func (g *Generator) generateImports() {
 		filename := fd.goFileName()
 		// By default, import path is the dirname of the Go filename.
 		importPath := path.Dir(filename)
+
+		// If a project uses Go Modules, then importPath may contain paths
+		// with the version of the package, for example: github.com/micro/go-api@v0.4.0/proto
+		// Therefore we need to remove this information from importPath
+		if strings.Contains(importPath, "@") {
+			reg := regexp.MustCompile("@v\\d+\\.\\d+\\.\\d+\\/")
+			importPath = reg.ReplaceAllString(importPath, "/")
+		}
+
 		if substitution, ok := g.ImportMap[s]; ok {
 			importPath = substitution
 		}


### PR DESCRIPTION
Hi there!

In my project, I use Go Modules and I have a `proto` file where I need to import other `proto` file, for example:
```proto
syntax = "proto3";

package go.micro.srv.example;

import "github.com/micro/go-api@v0.4.0/proto/api.proto";

service Example {
    rpc EntryPoint(go.api.Request) returns(go.api.Response);
}
```

Then I execute the command `protoc --proto_path=${GOPATH}/pkg/mod:. --micro_out=. --go_out=. proto/service.proto` and the result looks like this:

```go
package go_micro_srv_example

import proto "github.com/golang/protobuf/proto"
import fmt "fmt"
import math "math"
import go_api "github.com/micro/go-api@v0.4.0/proto"
```

As you can see, the last import is wrong, because the package version is defined in its path.
My patch fixes the problem with the wrong import.