### PR TITLE
Correctly format generated code

### DIFF
--- a/plugin/micro/micro.go
+++ b/plugin/micro/micro.go
@@ -87,9 +87,9 @@ func (g *micro) GenerateImports(file *generator.FileDescriptor) {
 		return
 	}
 	g.P("import (")
+	g.P(contextPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, contextPkgPath)))
 	g.P(clientPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, clientPkgPath)))
 	g.P(serverPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, serverPkgPath)))
-	g.P(contextPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, contextPkgPath)))
 	g.P(")")
 	g.P()
 }


### PR DESCRIPTION
Running gofmt on generated *micro.go files should produce no changes.