### PR TITLE
fix: skip import based on file pkg name

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1331,7 +1331,7 @@ func (g *Generator) generateImports() {
 	for i, s := range g.file.Dependency {
 		fd := g.fileByName(s)
 		// Do not import our own package.
-		if fd.PackageName() == g.packageName {
+		if g.file.PackageName() == g.packageName {
 			continue
 		}
 		filename := fd.goFileName()


### PR DESCRIPTION
`fd.PackageName()` Returns unique package name for file descriptor which generated as
https://github.com/micro/protoc-gen-micro/blob/5b1dcd09938fc1f18e8c9e23dc01947c696a7a2d/generator/generator.go#L674
So I suggest to use package of file we are compiling now `g.file.PackageName()` to skip own package import.