### PR TITLE
Add some flexibility

### DIFF
--- a/examples/greeter/greeter.micro.go
+++ b/examples/greeter/greeter.micro.go
@@ -80,11 +80,11 @@ type GreeterHandler interface {
 }
 
 func RegisterGreeterHandler(s server.Server, hdlr GreeterHandler, opts ...server.HandlerOption) error {
-	type greeter interface {
+	type EmbeddedGreeter interface {
 		Hello(ctx context.Context, in *Request, out *Response) error
 	}
 	type Greeter struct {
-		greeter
+		EmbeddedGreeter
 	}
 	h := &greeterHandler{hdlr}
 	return s.Handle(s.NewHandler(&Greeter{h}, opts...))

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -831,6 +831,7 @@ AllFiles:
 func (g *Generator) WrapTypes() {
 	g.allFiles = make([]*FileDescriptor, 0, len(g.Request.ProtoFile))
 	g.allFilesByName = make(map[string]*FileDescriptor, len(g.allFiles))
+
 	for _, f := range g.Request.ProtoFile {
 		// We must wrap the descriptors before we wrap the enums
 		descs := wrapDescriptors(f)


### PR DESCRIPTION
Back when Micro previously maintained a fork of golang/protobuf we constructed a server wrapper that provided a universal security layer around our service handlers based on if they implemented a set of interfaces.

When Micro moved to this much nicer implementation overall, that fell apart because on boot we do some reflecting around the handler. We can still find the implemented interfaces but due to the embedded interface being private we can't access any of the properties on the object from the implemented interface.

This patch exposes the embedded interface permitting the reflected calls to work again. I can't find any case in any of our numerous handlers this generates code that doesn't compile or conflicts with other code.

Also added is an argument for the command line that allows the substitution of import paths.

Similar to how M works `--micro_out=Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types:.`
You can do `--micro_out=Igithub.com/micro/server,github.com/fork/server`

I admit there might be a tiny portion of the userbase for this but I'm hoping you'll permit it on the basis that this is a code generation tool and by default it's behvaiour is otherwise unchanged.