### PR TITLE
Fixes #12 and doesn't cause #36.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1425,8 +1425,7 @@ func (g *Generator) generateImported(id *ImportedDescriptor) {
 		}
 	}
 	g.P("// ", sn, " from public import ", filename)
-	pkgName, _ := df.goPackageName()
-	g.usedPackages[pkgName] = sn
+	g.usedPackages[df.PackageName()] = sn
 
 	for _, sym := range df.exported[id.o] {
 		sym.GenerateAlias(g, df.PackageName())

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -691,7 +691,16 @@ func RegisterUniquePackageName(pkg string, f *FileDescriptor) string {
 	// Convert dots to underscores before finding a unique alias.
 	pkg = strings.Map(badToUnderscore, pkg)
 
-	for i, orig := 1, pkg; pkgNamesInUse[pkg]; i++ {
+	// Check to see if this file is in the same directory.
+	inLocalPackage := false
+	if f != nil {
+		if path.Dir(*f.Name) == "." {
+			// File is in the local package.
+			inLocalPackage = true
+		}
+	}
+
+	for i, orig := 1, pkg; pkgNamesInUse[pkg] && !inLocalPackage; i++ {
 		// It's a duplicate; must rename.
 		pkg = orig + strconv.Itoa(i)
 	}
@@ -817,7 +826,7 @@ AllFiles:
 		}
 		// The file is a dependency, so we want to ignore its go_package option
 		// because that is only relevant for its specific generated output.
-		pkg := f.GetPackage()
+		pkg, _ := f.goPackageName()
 		if pkg == "" {
 			pkg = baseName(*f.Name)
 		}
@@ -1353,7 +1362,8 @@ func (g *Generator) generateImports() {
 	for i, s := range g.file.Dependency {
 		fd := g.fileByName(s)
 		// Do not import our own package.
-		if fd.PackageName() == g.packageName {
+		pkgName, _ := fd.goPackageName()
+		if pkgName == g.packageName {
 			continue
 		}
 		filename := fd.goFileName(g.pathType)
@@ -1415,7 +1425,8 @@ func (g *Generator) generateImported(id *ImportedDescriptor) {
 		}
 	}
 	g.P("// ", sn, " from public import ", filename)
-	g.usedPackages[df.PackageName()] = sn
+	pkgName, _ := df.goPackageName()
+	g.usedPackages[pkgName] = sn
 
 	for _, sym := range df.exported[id.o] {
 		sym.GenerateAlias(g, df.PackageName())


### PR DESCRIPTION
Fixes the issue that prevents protoc-gen-micro from importing protobufs in the same folder.
Doesn't break importing protobufs with package names that have invalid Golang characters in them (e.g. 'go.api').

Supersedes pull request #35 which caused #36.

The issue was caused by referencing the goPackageName() instead of PackageName() when checking to see if packages have been used. Since the goPackageName() adjusted the name to conform to Golang requirements it wasn't being found in the map and was causing the import code to mis-generate.

This pull is identical to the previous one with two previous changes being omitted due to the above problem. This still fixes the issue of importing protobufs in the same folder as the source protobuf.

Let me know if I can do anything to test the change further.