### PR TITLE
Don't create conflicting type names.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -81,7 +81,7 @@ type Plugin interface {
 	Generate(file *FileDescriptor)
 	// GenerateImports produces the import declarations for this file.
 	// It is called after Generate.
-	GenerateImports(file *FileDescriptor)
+	GenerateImports(file *FileDescriptor, imports map[GoImportPath]GoPackageName)
 }
 
 var plugins []Plugin
@@ -1254,7 +1254,7 @@ func (g *Generator) generateImports() {
 	g.P()
 	// TODO: may need to worry about uniqueness across plugins
 	for _, p := range plugins {
-		p.GenerateImports(g.file)
+		p.GenerateImports(g.file, imports)
 		g.P()
 	}
 	g.P("// Reference imports to suppress errors if they are not otherwise used.")


### PR DESCRIPTION
Currently if `go_package` is defined  in a protobuf and a service has the same name as the package name a conflicting type will be generated which results in code that won't compile.

This fix adds the ability for plugins to see the imported packages and will append an underscore to the type name (_) in the event a generated type would collide with an existing package name.

This should fix #42.