### PR TITLE
feature: rename client method

### DIFF
--- a/plugin/micro/micro.go
+++ b/plugin/micro/micro.go
@@ -256,7 +256,7 @@ func (g *micro) generateClientSignature(servName string, method *pb.MethodDescri
 }
 
 func (g *micro) generateClientMethod(reqServ, servName, serviceDescVar string, method *pb.MethodDescriptorProto, descExpr string) {
-	reqMethod := fmt.Sprintf("%s.%s", servName, method.GetName())
+	reqMethod := fmt.Sprintf("/%s.%s/%s", reqServ, servName, method.GetName())
 	methName := generator.CamelCase(method.GetName())
 	inType := g.typeName(method.GetInputType())
 	outType := g.typeName(method.GetOutputType())


### PR DESCRIPTION
It is better for client method generated begin with "/"

for example:
before:
```req := c.c.NewRequest(c.name, "Frame.Snapshot", in)```
after:
```req := c.c.NewRequest(c.name, "/access.tc.Frame/Snapshot", in)```

